### PR TITLE
Check for listeners before calling OnControllerUpdate

### DIFF
--- a/GoogleVR/Scripts/Controller/GvrController.cs
+++ b/GoogleVR/Scripts/Controller/GvrController.cs
@@ -342,9 +342,11 @@ public class GvrController : MonoBehaviour {
       // This must be done at the end of the frame to ensure that all GameObjects had a chance
       // to read transient controller state (e.g. events, etc) for the current frame before
       // it gets reset.
-      yield return waitForEndOfFrame;
+      yield return waitForEndOfFrame;      
       UpdateController();
-      OnControllerUpdate();
+      if(OnControllerUpdate != null) {
+        OnControllerUpdate();
+      }
     }
   }
 }


### PR DESCRIPTION
Check OnControllerUpdate for listeners before calling to avoid a null pointer exception. In my app the controller is not active until an animation finishes playing so a NullReferenceException is thrown unless you check for listeners first.